### PR TITLE
change how package are used by shelly

### DIFF
--- a/shelly.asd
+++ b/shelly.asd
@@ -25,11 +25,12 @@
                :bordeaux-threads)
   :components ((:module "src"
                 :components
-                ((:file "shelly" :depends-on ("core" "install" "versions"))
-                 (:file "core" :depends-on ("impl" "error" "util"))
+                ((:file "shelly" :depends-on ("core" "install" "versions" "commands"))
+                 (:file "core" :depends-on ("impl" "error" "util" "commands"))
                  (:file "install" :depends-on ("impl" "versions" "util"))
                  (:file "versions")
-                 (:file "util")
+                 (:file "commands")
+                 (:file "util" :depends-on ("commands"))
                  (:file "impl")
                  (:file "error"))))
   :description "Run Common Lisp from shell easily."

--- a/src/commands.lisp
+++ b/src/commands.lisp
@@ -1,0 +1,17 @@
+#|
+  This file is a part of shelly project.
+  Copyright (c) 2012 Eitarow Fukamachi (e.arrows@gmail.com)
+|#
+
+(in-package :cl-user)
+(defpackage shelly.commands
+  (:use :cl))
+(in-package :shelly.commands)
+
+(cl-annot:enable-annot-syntax)
+
+@export
+(defvar *shelly-commands-package* :shelly.commands)
+
+@export
+(defvar *shelly-args* '())

--- a/src/shelly.lisp
+++ b/src/shelly.lisp
@@ -16,6 +16,8 @@
                 :rm-core)
   (:import-from :shelly.versions
                 :release-versions)
+  (:import-from :shelly.commands
+                :*shelly-commands-package*)
   (:export :run-repl
            :install
            :dump-core
@@ -31,9 +33,9 @@
     (format t "~&    ~(~A~)~%~{        ~A~^~%~}~2%"
             symbol
             (ppcre:split "\\n" (documentation symbol 'function))))
-  (let (symbols (cl-user-package (find-package :cl-user)))
-    (do-symbols (symbol cl-user-package)
-      (when (and (eq cl-user-package (symbol-package symbol)) (fboundp symbol))
+  (let (symbols (package (find-package *shelly-commands-package*)))
+    (do-symbols (symbol package)
+      (when (and (eq package (symbol-package symbol)) (fboundp symbol))
         (push symbol symbols)))
     (when symbols
       (format t "~&Local Commands:~%")

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -9,13 +9,15 @@
   (:import-from :cl-fad
                 :file-exists-p
                 :walk-directory
-                :copy-file))
+                :copy-file)
+  (:import-from :shelly.commands
+                :*shelly-commands-package*))
 (in-package :shelly.util)
 
 (cl-annot:enable-annot-syntax)
 
 @export
-(defun shadowing-use-package (packages-to-use &optional (package *package*))
+(defun shadowing-use-package (packages-to-use &optional (package (or (find-package *shelly-commands-package*) *package*)))
   (let ((packages-to-use (if (consp packages-to-use)
                              packages-to-use
                              (list packages-to-use))))
@@ -50,6 +52,7 @@
   (pushnew (directory-namestring (asdf::truenamize shlyfile))
            asdf:*central-registry*)
   (let ((*standard-output* (make-broadcast-stream))
+        (*package* (find-package *shelly-commands-package*))
         #+quicklisp (original-quickload #'ql:quickload))
     (flet (#+quicklisp
            (ql:quickload (systems &rest args)


### PR DESCRIPTION
I don't like common-lisp-user package to be contaminated.
The idea of how to deal packages are vary,so it's up to you to apply it or not.
Also I think it might be helpful to collect command functions like shelly.util::terminate to shelly.commands package
for people who want to write shell program in lisp.
