### PR TITLE
add --core and --no-core option

### DIFF
--- a/bin/shly
+++ b/bin/shly
@@ -45,7 +45,7 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
           'verbose'   => \$self->{verbose},
           'debug'     => \$self->{debug},
           'core=s'    => \$self->{core},
-          'no-core'    => \$self->{nocore},
+          'no-core'   => \$self->{nocore},
       );
   
       if ($libraries) {
@@ -115,11 +115,16 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
   
       my $command = App::shelly::command->new(verbose => $self->{verbose});
   
-      if (impl->('init_option')) {
-          $command->add_option(@{ impl->('init_option') });
+      if (defined $self->{core} &&-e $self->{core}) {
+          $command->set_core($self->{core});
       }
-      $command->requires_quicklisp;
-      $command->load_shelly;
+      else {
+          if (impl->('init_option')) {
+              $command->add_option(@{ impl->('init_option') });
+          }
+          $command->requires_quicklisp;
+          $command->load_shelly;
+      }
       $command->load_libraries($self->{load_libraries});
       $command->run_shelly_command($self->{argv});
   
@@ -133,9 +138,14 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
   
       $command->add_option(impl->('noinit_option'));
   
-      $command->load_quicklisp;
-      $command->requires_quicklisp;
-      $command->load_shelly;
+      if (defined $self->{core} &&-e $self->{core}) {
+          $command->set_core($self->{core});
+      }
+      else {
+          $command->load_quicklisp;
+          $command->requires_quicklisp;
+          $command->load_shelly;
+      }
       $command->check_shelly_version;
       $command->load_libraries($self->{load_libraries});
       $command->run_shelly_command($self->{argv});

--- a/bin/shly
+++ b/bin/shly
@@ -44,6 +44,8 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
           'file|f=s'  => \$self->{shlyfile},
           'verbose'   => \$self->{verbose},
           'debug'     => \$self->{debug},
+          'core=s'    => \$self->{core},
+          'no-core'    => \$self->{nocore},
       );
   
       if ($libraries) {
@@ -148,7 +150,15 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
   
       $command->add_option(impl->('noinit_option'));
   
-      if (!exists $ENV{SHELLY_PATH} && -e dumped_core_path) {
+      if(defined $self->{nocore}) {
+          $command->load_quicklisp;
+          $command->requires_quicklisp;
+          $command->load_shelly;
+      }
+      elsif (defined $self->{core} &&-e $self->{core}) {
+          $command->set_core($self->{core});
+      }
+      elsif (!exists $ENV{SHELLY_PATH} && -e dumped_core_path) {
           $command->set_core(dumped_core_path);
       }
       else {
@@ -251,6 +261,14 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
   =item B<--debug>
   
   This flag is for Shelly developers.
+  
+  =item B<--core file>
+  
+  Use the specified core file instead of the default.
+  
+  =item B<--no-core>
+  
+  Use implementation default core file.
   
   =back
   
@@ -4134,6 +4152,14 @@ Print some informations.
 =item B<--debug>
 
 This flag is for Shelly developers.
+
+=item B<--core file>
+
+Use the specified core file instead of the default.
+
+=item B<--no-core>
+
+Use implementation default core file.
 
 =back
 

--- a/bin/shly
+++ b/bin/shly
@@ -272,7 +272,7 @@ $fatpacked{"App/shelly.pm"} = <<'APP_SHELLY';
   
   This flag is for Shelly developers.
   
-  =item B<--core file>
+  =item B<--core [file]>
   
   Use the specified core file instead of the default.
   
@@ -4163,7 +4163,7 @@ Print some informations.
 
 This flag is for Shelly developers.
 
-=item B<--core file>
+=item B<--core [file]>
 
 Use the specified core file instead of the default.
 

--- a/p5-shelly/lib/App/shelly.pm
+++ b/p5-shelly/lib/App/shelly.pm
@@ -264,7 +264,7 @@ Print some informations.
 
 This flag is for Shelly developers.
 
-=item B<--core file>
+=item B<--core [file]>
 
 Use the specified core file instead of the default.
 

--- a/p5-shelly/lib/App/shelly.pm
+++ b/p5-shelly/lib/App/shelly.pm
@@ -107,11 +107,16 @@ sub _build_command_for_install {
 
     my $command = App::shelly::command->new(verbose => $self->{verbose});
 
-    if (impl->('init_option')) {
-        $command->add_option(@{ impl->('init_option') });
+    if (defined $self->{core} &&-e $self->{core}) {
+        $command->set_core($self->{core});
     }
-    $command->requires_quicklisp;
-    $command->load_shelly;
+    else {
+        if (impl->('init_option')) {
+            $command->add_option(@{ impl->('init_option') });
+        }
+        $command->requires_quicklisp;
+        $command->load_shelly;
+    }
     $command->load_libraries($self->{load_libraries});
     $command->run_shelly_command($self->{argv});
 
@@ -125,9 +130,14 @@ sub _build_command_for_dump_core {
 
     $command->add_option(impl->('noinit_option'));
 
-    $command->load_quicklisp;
-    $command->requires_quicklisp;
-    $command->load_shelly;
+    if (defined $self->{core} &&-e $self->{core}) {
+        $command->set_core($self->{core});
+    }
+    else {
+        $command->load_quicklisp;
+        $command->requires_quicklisp;
+        $command->load_shelly;
+    }
     $command->check_shelly_version;
     $command->load_libraries($self->{load_libraries});
     $command->run_shelly_command($self->{argv});

--- a/p5-shelly/lib/App/shelly.pm
+++ b/p5-shelly/lib/App/shelly.pm
@@ -36,6 +36,8 @@ sub parse_options {
         'file|f=s'  => \$self->{shlyfile},
         'verbose'   => \$self->{verbose},
         'debug'     => \$self->{debug},
+        'core=s'    => \$self->{core},
+        'no-core'   => \$self->{nocore},
     );
 
     if ($libraries) {
@@ -140,7 +142,15 @@ sub _build_command_for_others {
 
     $command->add_option(impl->('noinit_option'));
 
-    if (!exists $ENV{SHELLY_PATH} && -e dumped_core_path) {
+    if(defined $self->{nocore}) {
+        $command->load_quicklisp;
+        $command->requires_quicklisp;
+        $command->load_shelly;
+    }
+    elsif (defined $self->{core} &&-e $self->{core}) {
+        $command->set_core($self->{core});
+    }
+    elsif (!exists $ENV{SHELLY_PATH} && -e dumped_core_path) {
         $command->set_core(dumped_core_path);
     }
     else {
@@ -243,6 +253,14 @@ Print some informations.
 =item B<--debug>
 
 This flag is for Shelly developers.
+
+=item B<--core file>
+
+Use the specified core file instead of the default.
+
+=item B<--no-core>
+
+Use implementation default core file.
 
 =back
 

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -132,7 +132,8 @@ Add this to your shell rc file (\".bashrc\", \".zshrc\" and so on).
 
 @export
 (defun dump-core (&key (quit-lisp t) (path *dumped-core-path*))
-  "Dump Lisp core image file for faster startup."
+  "Dump Lisp core image file for faster startup.
+You can designate which path to dump by using \"--path\"."
   (cond
     (quit-lisp
      #+quicklisp (ql:quickload :shelly)

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -131,14 +131,14 @@ Add this to your shell rc file (\".bashrc\", \".zshrc\" and so on).
                      (merge-pathnames ".shelly/" (user-homedir-pathname))))
 
 @export
-(defun dump-core (&key (quit-lisp t))
+(defun dump-core (&key (quit-lisp t) (path *dumped-core-path*))
   "Dump Lisp core image file for faster startup."
   (cond
     (quit-lisp
      #+quicklisp (ql:quickload :shelly)
      #-quicklisp (asdf:load-system :shelly)
      (shelly.util:shadowing-use-package :shelly)
-     (save-core-image *dumped-core-path*))
+     (save-core-image path))
     (T
      (asdf:run-shell-command "~A ~A ~A '~S' ~A '~S' ~A '~A' ~A '~A' ~A '~S'"
       *current-lisp-path*
@@ -168,7 +168,7 @@ Add this to your shell rc file (\".bashrc\", \".zshrc\" and so on).
       *eval-option*
       "(shelly.util:shadowing-use-package :shelly)"
       *eval-option*
-      '(shelly.impl:save-core-image *dumped-core-path*)))))
+      '(shelly.impl:save-core-image path)))))
 
 @export
 (defun rm-core ()


### PR DESCRIPTION
This patch enable user to specify which corefile to use.
Points that I don't have confidence with are the name of the option 'no-core' and The first attempt to write perl :)
I'm appreciate if anyone have time and review it whether it acceptable or not.
