### PR TITLE
support cygwin with sbcl 

### DIFF
--- a/bin/shly
+++ b/bin/shly
@@ -135,19 +135,19 @@ case "$LISP_IMPL" in
         impl_cmd=$(printf -- "--noinform\n--non-interactive")
         noinit_cmd=$(printf -- "--no-sysinit\n--no-userinit")
         if [ -z "$CIM_HOME" ] || [ "$LISP_IMPL" = "sbcl-system" ]; then
-	    if [[ "$OSTYPE" == "linux-gnu" ]]; then
-		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
-		    SBCL_HOME="${sbcl_base}/lib/sbcl"
-	    elif [[ "$OSTYPE" == "darwin"* ]]; then
-		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
-		    SBCL_HOME="${sbcl_base}/lib/sbcl"
-	    elif [[ "$OSTYPE" == "cygwin" ]]; then
-		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
-		    SBCL_HOME=$(echo `cygpath -m ${sbcl_base}`|sed -e "s/\n//g")
-	    elif [[ "$OSTYPE" == "msys" ]]; then
-		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
-		    SBCL_HOME="${sbcl_base}"
-	    fi
+            if [[ "$OSTYPE" == "linux-gnu" ]]; then
+                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
+                    SBCL_HOME="${sbcl_base}/lib/sbcl"
+            elif [[ "$OSTYPE" == "darwin"* ]]; then
+                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
+                    SBCL_HOME="${sbcl_base}/lib/sbcl"
+            elif [[ "$OSTYPE" == "cygwin" ]]; then
+                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
+                    SBCL_HOME=$(echo `cygpath -m ${sbcl_base}`|sed -e "s/\n//g")
+            elif [[ "$OSTYPE" == "msys" ]]; then
+                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
+                    SBCL_HOME="${sbcl_base}"
+            fi
         else
             SBCL_HOME="$CIM_HOME/impls/$LISP_IMPL/lib/sbcl"
         fi

--- a/bin/shly
+++ b/bin/shly
@@ -188,7 +188,7 @@ case "$LISP_IMPL" in
 esac
 
 : ${SHELLY_HOME:="$HOME/.shelly"}
-if [ $OSTYPE="cygwin" ]; then
+if [ "$OSTYPE" = "cygwin" ]; then
     SHELLY_HOME=`cygpath -m $SHELLY_HOME`
 fi
 

--- a/bin/shly
+++ b/bin/shly
@@ -135,19 +135,24 @@ case "$LISP_IMPL" in
         impl_cmd=$(printf -- "--noinform\n--non-interactive")
         noinit_cmd=$(printf -- "--no-sysinit\n--no-userinit")
         if [ -z "$CIM_HOME" ] || [ "$LISP_IMPL" = "sbcl-system" ]; then
-            if [ "$OSTYPE" = "linux-gnu" ]; then
+            case "$OSTYPE" in
+                lnux-gnu)
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
                     SBCL_HOME="${sbcl_base}/lib/sbcl"
-            elif [ "$OSTYPE" = "darwin"* ]; then
+                    ;;
+                darwin*)
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
                     SBCL_HOME="${sbcl_base}/lib/sbcl"
-            elif [ "$OSTYPE" = "cygwin" ]; then
+                    ;;
+                cygwin)
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
                     SBCL_HOME=$(echo `cygpath -m ${sbcl_base}`|sed -e "s/\n//g")
-            elif [ "$OSTYPE" = "msys" ]; then
-                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
-                    SBCL_HOME="${sbcl_base}"
-            fi
+                    ;;
+                *)
+                    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
+                    SBCL_HOME="${sbcl_base}/lib/sbcl"
+                    ;;
+            esac
         else
             SBCL_HOME="$CIM_HOME/impls/$LISP_IMPL/lib/sbcl"
         fi

--- a/bin/shly
+++ b/bin/shly
@@ -135,16 +135,16 @@ case "$LISP_IMPL" in
         impl_cmd=$(printf -- "--noinform\n--non-interactive")
         noinit_cmd=$(printf -- "--no-sysinit\n--no-userinit")
         if [ -z "$CIM_HOME" ] || [ "$LISP_IMPL" = "sbcl-system" ]; then
-            if [[ "$OSTYPE" == "linux-gnu" ]]; then
+            if [ "$OSTYPE" = "linux-gnu" ]; then
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
                     SBCL_HOME="${sbcl_base}/lib/sbcl"
-            elif [[ "$OSTYPE" == "darwin"* ]]; then
+            elif [ "$OSTYPE" = "darwin"* ]; then
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
                     SBCL_HOME="${sbcl_base}/lib/sbcl"
-            elif [[ "$OSTYPE" == "cygwin" ]]; then
+            elif [ "$OSTYPE" = "cygwin" ]; then
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
                     SBCL_HOME=$(echo `cygpath -m ${sbcl_base}`|sed -e "s/\n//g")
-            elif [[ "$OSTYPE" == "msys" ]]; then
+            elif [ "$OSTYPE" = "msys" ]; then
                     sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
                     SBCL_HOME="${sbcl_base}"
             fi

--- a/bin/shly
+++ b/bin/shly
@@ -135,8 +135,19 @@ case "$LISP_IMPL" in
         impl_cmd=$(printf -- "--noinform\n--non-interactive")
         noinit_cmd=$(printf -- "--no-sysinit\n--no-userinit")
         if [ -z "$CIM_HOME" ] || [ "$LISP_IMPL" = "sbcl-system" ]; then
-            sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
-            SBCL_HOME="${sbcl_base}/lib/sbcl"
+	    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
+		    SBCL_HOME="${sbcl_base}/lib/sbcl"
+	    elif [[ "$OSTYPE" == "darwin"* ]]; then
+		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/bin/sbcl')
+		    SBCL_HOME="${sbcl_base}/lib/sbcl"
+	    elif [[ "$OSTYPE" == "cygwin" ]]; then
+		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
+		    SBCL_HOME=$(echo `cygpath -m ${sbcl_base}`|sed -e "s/\n//g")
+	    elif [[ "$OSTYPE" == "msys" ]]; then
+		    sbcl_base=$(expr "$LISP_BINARY" : '\(.*\)/sbcl')
+		    SBCL_HOME="${sbcl_base}"
+	    fi
         else
             SBCL_HOME="$CIM_HOME/impls/$LISP_IMPL/lib/sbcl"
         fi

--- a/bin/shly
+++ b/bin/shly
@@ -188,6 +188,10 @@ case "$LISP_IMPL" in
 esac
 
 : ${SHELLY_HOME:="$HOME/.shelly"}
+if [ $OSTYPE="cygwin" ]; then
+    SHELLY_HOME=`cygpath -m $SHELLY_HOME`
+fi
+
 export SHELLY_HOME
 
 dumped_core_path() {

--- a/shelly.asd
+++ b/shelly.asd
@@ -23,7 +23,8 @@
                :bordeaux-threads
                :local-time
                :trivial-signal
-               :babel)
+               :babel
+               :uiop)
   :components ((:module "src"
                 :components
                 ((:file "shelly" :depends-on ("core" "install" "versions" "util"))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -162,7 +162,6 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
   (let* ((home-config-path (shelly-home))
          (version (slot-value (asdf:find-system :shelly)
                               'asdf:version)))
-
     ;; Delete dumped cores of all Lisp implementations
     ;; if the installing version is different from the current version.
     (let ((current-installed-version (getenv "SHELLY_VERSION")))
@@ -172,14 +171,17 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
              (fad:list-directory (merge-pathnames "dumped-cores/" home-config-path)))))
 
     (ensure-directories-exist home-config-path)
-
     (with-open-file (out (merge-pathnames "config" home-config-path)
                          :direction :output
                          :if-does-not-exist :create
                          :if-exists :supersede)
       (format out "SHELLY_LISP_IMPL=\"~A\"~%SHELLY_LISP_BINARY=\"~A\"~%SHELLY_VERSION=\"~A\"~%QUICKLISP_HOME=~:[~;~:*\"~A\"~]~%"
               *current-lisp-name*
-              *current-lisp-path*
+	      #-win32
+              *current-lisp-path* 
+	      #+win32
+              (coerce (mapcar #'(lambda (x) (if (char= #\\ x) #\/ x)) 
+			      (coerce *current-lisp-path* 'list)) 'string)
               version
               #+quicklisp ql:*quicklisp-home*
               #-quicklisp nil))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -180,8 +180,7 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
               #-win32
               *current-lisp-path*
               #+win32
-              (coerce (mapcar #'(lambda (x) (if (char= #\\ x) #\/ x))
-                              (coerce *current-lisp-path* 'list)) 'string)
+              (substitute #\/ #\\ *current-lisp-path*)
               version
               #+quicklisp ql:*quicklisp-home*
               #-quicklisp nil))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -210,8 +210,10 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
           (shly-bin (merge-pathnames #P"lib/shelly/bin/shly" install-dir)))
       (ensure-directories-exist install-bin-dir)
       ;; XXX: must be more portable.
-      (asdf:run-shell-command "chmod u+x ~A" shly-bin)
-      (asdf:run-shell-command "ln -s ~A ~A" shly-bin install-bin-dir))
+      (uiop:run-program (list "chmod" "u+x" (princ-to-string shly-bin)))
+      (uiop:run-program (list "ln" "-s"
+                              (princ-to-string shly-bin)
+                              (princ-to-string install-bin-dir))))
 
     (dump-core :quit-lisp nil))
 
@@ -232,76 +234,44 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
     (format *error-output* "~&~A does not support 'dump-core'.~%"
             *current-lisp-name*))
 
-  #+asdf3
   #+(or sbcl allegro ccl clisp cmu)
-  (uiop:run-program
-   (append (list *current-lisp-path*)
-           #+ccl '("--no-init" "--quiet" "--batch")
-           #+sbcl '("--noinform" "--no-sysinit" "--no-userinit" "--non-interactive")
-           #+allegro '("--qq")
-           #+clisp '("-norc" "--quiet" "--silent" "-on-error" "exit")
-           #+cmu '("-noinit")
-           (list
-            *eval-option*
-            (format nil "~S"
-                    #+quicklisp
-                    (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
-                      (if (probe-file quicklisp-init)
-                          `(load ,quicklisp-init)
-                          ""))
-                    #-quicklisp
-                    '(require (quote asdf)))
+  (uiop:run-program `(,*current-lisp-path*
+                      #+ccl
+                      ,@(list "--no-init" "--quiet" "--batch")
+                      #+sbcl
+                      ,@(list "--noinform" "--no-sysinit" "--no-userinit" "--non-interactive")
+                      #+allegro
+                      ,@(list "--qq")
+                      #+clisp
+                      ,@(list "-norc" "--quiet" "--silent" "-on-error" "exit")
+                      #+cmu
+                      ,@(list "-noinit")
 
-            *eval-option*
-            (format nil "~S" `(push ,(asdf:system-source-directory :shelly) asdf:*central-registry*))
+                      ,*eval-option*
+                      ,(prin1-to-string
+                        #+quicklisp
+                        (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
+                          (if (probe-file quicklisp-init)
+                              `(load ,quicklisp-init)
+                              "")))
+                      #-quicklisp
+                      '(require (quote asdf))
 
-            *eval-option*
-            (format nil
-                    "(let ((*standard-output* (make-broadcast-stream)) #+allegro(*readtable* (copy-readtable))) (mapc #+quicklisp (function ql:quickload) #-quicklisp (function asdf:load-system) (list ~{:~A~^ ~})))"
-                    (cons :shelly
-                          load-systems))
+                      ,*eval-option*
+                      ,(prin1-to-string `(push ,(asdf:system-source-directory :shelly) asdf:*central-registry*))
 
-            *eval-option*
-            (format nil "~S" `(shelly.util:shadowing-use-package :shelly))
+                      ,*eval-option*
+                      ,(format nil
+                               "(let ((*standard-output* (make-broadcast-stream)) #+allegro(*readtable* (copy-readtable))) (mapc #+quicklisp (function ql:quickload) #-quicklisp (function asdf:load-system) (list ~{:~A~^ ~})))"
+                               (cons :shelly
+                                     load-systems))
 
-            *eval-option*
-            (format nil "~S" `(shelly.impl:save-core-image ,(princ-to-string output))))))
+                      ,*eval-option*
+                      ,(prin1-to-string `(shelly.util:shadowing-use-package :shelly))
 
-  #-asdf3
-  #+asdf2
-  #+(or sbcl allegro ccl clisp cmu)
-  (asdf:run-shell-command "~A ~A ~A '~S' ~A '~S' ~A '~A' ~A '~S' ~A '~S'"
-                         *current-lisp-path*
+                      ,*eval-option*
+                      ,(prin1-to-string `(shelly.impl:save-core-image ,(princ-to-string output)))))
 
-                         #+ccl "--no-init --quiet --batch"
-                         #+sbcl "--noinform --no-sysinit --no-userinit --non-interactive"
-                         #+allegro "--qq"
-                         #+clisp "-norc --quiet --silent -on-error exit"
-                         #+cmu "-noinit"
-
-                         *eval-option*
-                         #+quicklisp
-                         (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
-                           (if (probe-file quicklisp-init)
-                               `(load ,quicklisp-init)
-                               ""))
-                         #-quicklisp
-                         '(require (quote asdf))
-
-                         *eval-option*
-                         `(push ,(asdf:system-source-directory :shelly) asdf:*central-registry*)
-
-                         *eval-option*
-                         (format nil
-                                 "(let ((*standard-output* (make-broadcast-stream)) #+allegro(*readtable* (copy-readtable))) (mapc #+quicklisp (function ql:quickload) #-quicklisp (function asdf:load-system) (list ~{:~A~^ ~})))"
-                                 (cons :shelly
-                                       load-systems))
-
-                         *eval-option*
-                         `(shelly.util:shadowing-use-package :shelly)
-
-                         *eval-option*
-                         `(shelly.impl:save-core-image ,(princ-to-string output)))
   (when quit-lisp
     (terminate))
 

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -177,11 +177,11 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
                          :if-exists :supersede)
       (format out "SHELLY_LISP_IMPL=\"~A\"~%SHELLY_LISP_BINARY=\"~A\"~%SHELLY_VERSION=\"~A\"~%QUICKLISP_HOME=~:[~;~:*\"~A\"~]~%"
               *current-lisp-name*
-	      #-win32
-              *current-lisp-path* 
-	      #+win32
-              (coerce (mapcar #'(lambda (x) (if (char= #\\ x) #\/ x)) 
-			      (coerce *current-lisp-path* 'list)) 'string)
+              #-win32
+              *current-lisp-path*
+              #+win32
+              (coerce (mapcar #'(lambda (x) (if (char= #\\ x) #\/ x))
+                              (coerce *current-lisp-path* 'list)) 'string)
               version
               #+quicklisp ql:*quicklisp-home*
               #-quicklisp nil))
@@ -235,19 +235,19 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
   #+(and sbcl win32)
   (uiop:run-program (list *current-lisp-path*
                           "--noinform"
-			  "--no-sysinit"
-			  "--no-userinit"
-			  "--non-interactive"
+                          "--no-sysinit"
+                          "--no-userinit"
+                          "--non-interactive"
 
                           *eval-option*
-			  (format nil "~S"
-				  #+quicklisp
-				  (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
-				    (if (probe-file quicklisp-init)
-					`(load ,quicklisp-init)
-					""))
-				  #-quicklisp
-				  '(require (quote asdf)))
+                          (format nil "~S"
+                                  #+quicklisp
+                                  (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
+                                    (if (probe-file quicklisp-init)
+                                        `(load ,quicklisp-init)
+                                        ""))
+                                  #-quicklisp
+                                  '(require (quote asdf)))
 
                           *eval-option*
                           (format nil "~S" `(push ,(asdf:system-source-directory :shelly) asdf:*central-registry*))
@@ -259,10 +259,10 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
                                         load-systems))
 
                           *eval-option*
-			  (format nil "~S" `(shelly.util:shadowing-use-package :shelly))
+                          (format nil "~S" `(shelly.util:shadowing-use-package :shelly))
 
                           *eval-option*
-			  (format nil "~S" `(shelly.impl:save-core-image ,(princ-to-string output)))))
+                          (format nil "~S" `(shelly.impl:save-core-image ,(princ-to-string output)))))
   #+(and sbcl win32)
   (when quit-lisp
     (terminate))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -231,7 +231,8 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
   (when quit-lisp
     (format *error-output* "~&~A does not support 'dump-core'.~%"
             *current-lisp-name*))
-  #+(and sbcl win32)
+
+  #+(or sbcl allegro ccl clisp cmu)
   (uiop:run-program (list *current-lisp-path*
                           "--noinform"
                           "--no-sysinit"
@@ -262,45 +263,9 @@ if ( -e ~Ashelly/init.csh ) source ~:*~Alib/shelly/init.csh"
 
                           *eval-option*
                           (format nil "~S" `(shelly.impl:save-core-image ,(princ-to-string output)))))
-  #+(and sbcl win32)
   (when quit-lisp
     (terminate))
 
-  #+(or (and sbcl (not win32)) allegro ccl clisp cmu)
-  (asdf:run-shell-command "~A ~A ~A '~S' ~A '~S' ~A '~A' ~A '~S' ~A '~S'"
-                          *current-lisp-path*
-
-                          #+ccl "--no-init --quiet --batch"
-                          #+sbcl "--noinform --no-sysinit --no-userinit --non-interactive"
-                          #+allegro "--qq"
-                          #+clisp "-norc --quiet --silent -on-error exit"
-                          #+cmu "-noinit"
-
-                          *eval-option*
-                          #+quicklisp
-                          (let ((quicklisp-init (merge-pathnames #P"setup.lisp" ql:*quicklisp-home*)))
-                            (if (probe-file quicklisp-init)
-                                `(load ,quicklisp-init)
-                                ""))
-                          #-quicklisp
-                          '(require (quote asdf))
-
-                          *eval-option*
-                          `(push ,(asdf:system-source-directory :shelly) asdf:*central-registry*)
-
-                          *eval-option*
-                          (format nil
-                                  "(let ((*standard-output* (make-broadcast-stream)) #+allegro(*readtable* (copy-readtable))) (mapc #+quicklisp (function ql:quickload) #-quicklisp (function asdf:load-system) (list ~{:~A~^ ~})))"
-                                  (cons :shelly
-                                        load-systems))
-
-                          *eval-option*
-                          `(shelly.util:shadowing-use-package :shelly)
-
-                          *eval-option*
-                          `(shelly.impl:save-core-image ,(princ-to-string output)))
-  (when quit-lisp
-    (terminate))
   (values))
 
 (defun local-dump-core (&rest systems)

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -139,7 +139,7 @@
       (load-shlyfile shlyfile))))
 
 (defun copy-directory (from to &key overwrite)
-  (let ((len (length (namestring (truename from)))))
+  (let ((len (length (namestring (truename (first (directory from)))))))
     (fad:walk-directory
      from
      (lambda (x)


### PR DESCRIPTION
This patch enable to support  Cygwin & sbcl .
- add manipulate $OSTYPE code to shly
- change asdf:run-shell-command to uiop:run-program

thank you.
